### PR TITLE
Fixed command for builtin cd

### DIFF
--- a/functions/__fzf_cd.fish
+++ b/functions/__fzf_cd.fish
@@ -29,7 +29,7 @@ function __fzf_cd -d "Change directory"
     eval "$COMMAND | "(__fzfcmd)" +m $FZF_DEFAULT_OPTS $FZF_CD_OPTS --query \"$fzf_query\"" | read -l select
 
     if not test -z "$select"
-        command cd "$select"
+        builtin cd "$select"
 
         # Remove last token from commandline.
         commandline -t ""


### PR DESCRIPTION
This commit forces fzf to use the builtin cd, which didn't work in the last commit. 