### PR TITLE
Properly escaping strings in preview window

### DIFF
--- a/functions/__fzf_complete_preview.fish
+++ b/functions/__fzf_complete_preview.fish
@@ -13,12 +13,12 @@ function __fzf_complete_preview -d 'generate preview for completion widget.
 
     # list directories on preview
     if test -d "$argv[1]"
-        eval $FZF_PREVIEW_DIR_CMD $argv[1]
+        eval $FZF_PREVIEW_DIR_CMD (string escape $argv[1])
     end
 
     # show ten lines of non-binary files preview
     if test -f "$argv[1]"; and grep -qI . "$argv[1]"
-        eval $FZF_PREVIEW_FILE_CMD $argv[1]
+        eval $FZF_PREVIEW_FILE_CMD (string escape $argv[1])
     end
 
     # if fish knows about it, let it show info

--- a/functions/__fzf_open.fish
+++ b/functions/__fzf_open.fish
@@ -17,7 +17,7 @@ function __fzf_open -d "Open files and directories."
 
     set -l preview_cmd
     if set -q FZF_ENABLE_OPEN_PREVIEW
-        set preview_cmd "--preview-window=right:wrap --preview=\"fish -c \\\"__fzf_complete_preview '{}'\\\"\""
+        set preview_cmd "--preview-window=right:wrap --preview='fish -c \"__fzf_complete_preview {}\"'"
     end
 
     set -q FZF_OPEN_COMMAND
@@ -27,7 +27,7 @@ function __fzf_open -d "Open files and directories."
     -o -type d -print \
     -o -type l -print 2> /dev/null | sed 's@^\./@@'"
 
-    eval "$FZF_OPEN_COMMAND | "(__fzfcmd) "$preview_cmd -m $FZF_DEFAULT_OPTS $FZF_OPEN_OPTS --query \"$fzf_query\"" | read -l select
+    eval "$FZF_OPEN_COMMAND | "(__fzfcmd) $preview_cmd "-m $FZF_DEFAULT_OPTS $FZF_OPEN_OPTS --query \"$fzf_query\"" | read -l select
 
     # set how to open
     set -l open_cmd


### PR DESCRIPTION
This fixes some issues with string escaping. For example, a file with the name `File_with_parens(touch exec.txt).txt` will cause `touch exec.txt` to run. It also fixes some issues when the file or directory had spaces in the name. 