### PR TITLE
Fisher V3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,26 @@
 
 Integrate [fzf](https://github.com/junegunn/fzf) functionality into [fish](https://github.com/fish-shell/fish-shell)! Includes handy functions to do the following using `fzf`
 
-* command tab completion
-* search command history
-* find and cd into sub-directories
-* find and open files
+- command tab completion
+- search command history
+- find and cd into sub-directories
+- find and open files
 
 All functions
 
-* are lazily-loaded to keep shell startup time down
-* have preset but configurable key bindings
+- are lazily-loaded to keep shell startup time down
+- have preset but configurable key bindings
 
 Heavily adapted from @hauleth's PR.
 
-Note that the `fzf` utility has its [own out-of-the-box fish plugin](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). What sets this plugin apart is that it has a couple more integrations, most notably tab completion, and will probably be updated more frequently. They are not compatible so either use one or the other.
-## Install
+Note that the `fzf` utility has its [own out-of-the-box fish package](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). What sets this package apart is that it has a couple more integrations, most notably tab completion, and will probably be updated more frequently. They are not compatible so either use one or the other.
 
-With [fisherman]
+## Installation
+
+With [fisher]
 
 ```
-fisher jethrokuan/fzf
+fisher add jethrokuan/fzf
 ```
 
 With [oh-my-fish]
@@ -31,25 +32,25 @@ omf install https://github.com/jethrokuan/fzf
 
 ## Requirements
 
-* fish version: `>=2.4.0`
-* fzf versions: `>0.11.3`
+- [fish](https://github.com/fish-shell/fish-shell) `>=2.4.0`
+- [fzf](https://github.com/junegunn/fzf) `>0.11.3`
 
-## FZF binary
-This plugin will fail if the `fzf` binary is not detected in your `PATH`.
+## About the fzf binary
 
-The recommended means of installing `fzf` is through your respective
-package managers. 
+This package will fail if the `fzf` binary is not detected in your `PATH`.
+
+See the [fzf documentation](https://github.com/junegunn/fzf#installation) for instructions to install `fzf` on your system.
 
 ## Usage
 
-| Legacy      | New Keybindings   | Remarks                                                       |
-| -------     | ----------------- | ------------------------------------------------------------- |
-| Ctrl-t      | Ctrl-f            | Find a file.                                                  |
-| Ctrl-r      | Ctrl-r            | Search through command history.                               |
-| Alt-c       | Alt-o             | cd into sub-directories (recursively searched).               |
-| Alt-Shift-c | Alt-Shift-o       | cd into sub-directories, including hidden ones.               |
-| Ctrl-o      | Ctrl-o            | Open a file/dir using default editor ($EDITOR)                |
-| Ctrl-g      | Ctrl-g            | Open a file/dir using xdg-open or open command                |
+| Legacy      | New Keybindings | Remarks                                         |
+| ----------- | --------------- | ----------------------------------------------- |
+| Ctrl-t      | Ctrl-f          | Find a file.                                    |
+| Ctrl-r      | Ctrl-r          | Search through command history.                 |
+| Alt-c       | Alt-o           | cd into sub-directories (recursively searched). |
+| Alt-Shift-c | Alt-Shift-o     | cd into sub-directories, including hidden ones. |
+| Ctrl-o      | Ctrl-o          | Open a file/dir using default editor ($EDITOR)  |
+| Ctrl-g      | Ctrl-g          | Open a file/dir using xdg-open or open command  |
 
 Legacy keybindings are kept by default, but these have conflict with
 keybindings in fish 2.4.0. If you want to use the new keybindings,
@@ -65,10 +66,10 @@ key to act as +Esc (iTerm2 Preferences > Profiles > Default > Keys >
 Left option (⌥) acts as: > +Esc), then alt-c will work for fzf as
 documented.
 
-
 ## Commands
+
 | Variable                       | Remarks                                                     | Example                                                       |
-| ------------------------------ | ------------------------------------------------------------| ------------------------------------------------------------- |
+| ------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------- |
 | `FZF_FIND_FILE_COMMAND`        | Modify the command used to generate the list of files       | `set -U FZF_FIND_FILE_COMMAND "ag -l --hidden --ignore .git"` |
 | `FZF_CD_COMMAND`               | Similar to ^                                                | Similar to ^                                                  |
 | `FZF_CD_WITH_HIDDEN_COMMAND`   | Similar to ^                                                | Similar to ^                                                  |
@@ -79,19 +80,24 @@ documented.
 | `FZF_PREVIEW_DIR_COMMAND`      | Modify the command used to generate preview of directories. | `set -U FZF_PREVIEW_FILE_COMMAND "ls"`                        |
 
 ## Variables
-| Variable                    | Remarks                                                        | Example                                               |
-| --------------------------- | -------------------------------------------------------------- | ----------------------------------------------------  |
-| `FZF_DEFAULT_OPTS`          | Default options passed to every fzf command                    | `set -U FZF_DEFAULT_OPTS "--height 40"`               |
-| `FZF_FIND_FILE_OPTS`        | Pass in additional arguments to the fzf command for find file  | `set -U FZF_FIND_FILE_OPTS "--reverse --inline-info"` |
-| `FZF_CD_OPTS`               | Similar to ^                                                   | Similar to ^                                          |
-| `FZF_CD_WITH_HIDDEN_OPTS`   | Similar to ^                                                   | Similar to ^                                          |
-| `FZF_FIND_AND_EXECUTE_OPTS` | Similar to ^                                                   | Similar to ^                                          |
-| `FZF_REVERSE_ISEARCH_OPTS`  | Similar to ^                                                   | Similar to ^                                          |
-| `FZF_OPEN_OPTS`             | Similar to ^                                                   | Similar to ^                                          |
-| `FZF_TMUX`                  | Runs a tmux-friendly version of fzf instead.                   | `set -U FZF_TMUX 1`                                   |
-| `FZF_COMPLETE`              | Enable fzf for fish tab completion.                            | `set -U FZF_COMPLETE 1`                               |
-| `FZF_ENABLE_OPEN_PREVIEW`   | Enable preview window open command.                            | `set -U FZF_ENABLE_OPEN_PREVIEW 1`                    |
 
-[tmux]:https://tmux.github.io/
-[fisherman]: https://github.com/jorgebucaran/fisher
+| Variable                    | Remarks                                                       | Example                                               |
+| --------------------------- | ------------------------------------------------------------- | ----------------------------------------------------- |
+| `FZF_DEFAULT_OPTS`          | Default options passed to every fzf command                   | `set -U FZF_DEFAULT_OPTS "--height 40"`               |
+| `FZF_FIND_FILE_OPTS`        | Pass in additional arguments to the fzf command for find file | `set -U FZF_FIND_FILE_OPTS "--reverse --inline-info"` |
+| `FZF_CD_OPTS`               | Similar to ^                                                  | Similar to ^                                          |
+| `FZF_CD_WITH_HIDDEN_OPTS`   | Similar to ^                                                  | Similar to ^                                          |
+| `FZF_FIND_AND_EXECUTE_OPTS` | Similar to ^                                                  | Similar to ^                                          |
+| `FZF_REVERSE_ISEARCH_OPTS`  | Similar to ^                                                  | Similar to ^                                          |
+| `FZF_OPEN_OPTS`             | Similar to ^                                                  | Similar to ^                                          |
+| `FZF_TMUX`                  | Runs a tmux-friendly version of fzf instead.                  | `set -U FZF_TMUX 1`                                   |
+| `FZF_COMPLETE`              | Enable fzf for fish tab completion.                           | `set -U FZF_COMPLETE 1`                               |
+| `FZF_ENABLE_OPEN_PREVIEW`   | Enable preview window open command.                           | `set -U FZF_ENABLE_OPEN_PREVIEW 1`                    |
+
+[tmux]: https://tmux.github.io/
+[fisher]: https://github.com/jorgebucaran/fisher
 [oh-my-fish]: https://github.com/oh-my-fish/oh-my-fish
+
+## License
+
+fzf is MIT licensed. See the [LICENSE](LICENSE.md) for details.

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -3,3 +3,7 @@ set -q FZF_DEFAULT_OPTS; or set -U FZF_DEFAULT_OPTS "--height $FZF_TMUX_HEIGHT"
 set -q FZF_LEGACY_KEYBINDINGS; or set -U FZF_LEGACY_KEYBINDINGS 1
 set -q FZF_PREVIEW_FILE_CMD; or set -U FZF_PREVIEW_FILE_CMD "head -n 10"
 set -q FZF_PREVIEW_DIR_CMD; or set -U FZF_PREVIEW_DIR_CMD "ls"
+
+function fzf_uninstall -e fzf_uninstall
+  # Erase env vars and __fzf functions here.
+end

--- a/conf.d/fzf_key_bindings.fish
+++ b/conf.d/fzf_key_bindings.fish
@@ -35,3 +35,7 @@ end
 if set -q FZF_COMPLETE
     bind \t '__fzf_complete'
 end
+
+function fzf_key_bindings_uninstall -e fzf_key_bindings_uninstall
+  # Erase key bindings here.
+end


### PR DESCRIPTION
@jethrokuan With this PR fzf uses the shell's canonical way to run fish code on startup, adding support for fisher V3.

 ~~I'm not done yet~~. I'm done now! ~~We need to add one dependency to support key bindings. This depedency is not yet up on GitHub, but I already have the implementation.~~ 

We don't need any dependencies now! 🎉 




