### PR TITLE
Fallback using "contains" if argparse does not exist (Fish shell v<2.7)

### DIFF
--- a/functions/__fzf_cd.fish
+++ b/functions/__fzf_cd.fish
@@ -3,9 +3,15 @@ function __fzf_cd -d "Change directory"
     set -l dir $commandline[1]
     set -l fzf_query $commandline[2]
 
-    set -l options  "h/hidden"
-
-    argparse $options -- $argv
+    # Fish shell version >= v2.7, use argparse
+    if type -q argparse
+        set -l options  "h/hidden"
+        argparse $options -- $argv
+    else # Fallback for fish shell version < 2.7
+        if contains -- --hidden $argv; or contains -- -h $argv
+            set _flag_hidden "yes"
+        end
+    end
 
     set -l COMMAND
 

--- a/functions/__fzf_open.fish
+++ b/functions/__fzf_open.fish
@@ -11,9 +11,18 @@ function __fzf_open -d "Open files and directories."
     set -l dir $commandline[1]
     set -l fzf_query $commandline[2]
 
-    set -l options "e/editor" "p/preview=?"
-
-    argparse $options -- $argv
+    # Fish shell version >= v2.7, use argparse
+    if type -q argparse
+        set -l options "e/editor" "p/preview=?"
+        argparse $options -- $argv
+    else # Fallback for fish shell version < 2.7
+        if contains -- --editor $argv; or contains -- -e $argv
+            set _flag_editor "yes"
+        end
+        if contains -- --preview $argv; or contains -- -p $argv
+            set _flag_preview "yes"
+        end
+    end
 
     set -l preview_cmd
     if set -q FZF_ENABLE_OPEN_PREVIEW


### PR DESCRIPTION
I failed to use open/preview with fzf with Fish shell version 2.4.0, because `argparse` was used, which was not introduced until Fish version 2.7.

I managed to create a fallback version using `contains,` which works for me, so I hope you will consider this PR.