### PR TITLE
redo argparse fallback so it actually works on 2.7

### DIFF
--- a/functions/__fzf_cd.fish
+++ b/functions/__fzf_cd.fish
@@ -3,15 +3,19 @@ function __fzf_cd -d "Change directory"
     set -l dir $commandline[1]
     set -l fzf_query $commandline[2]
 
-    # Fish shell version >= v2.7, use argparse
-    if type -q argparse
-        set -l options  "h/hidden"
-        argparse $options -- $argv
-    else # Fallback for fish shell version < 2.7
+    if not type -q argparse
+        # Fallback for fish shell version < 2.7
+        function argparse
+            functions -e argparse # deletes itself
+        end
         if contains -- --hidden $argv; or contains -- -h $argv
             set _flag_hidden "yes"
         end
     end
+
+    # Fish shell version >= v2.7, use argparse
+    set -l options  "h/hidden"
+    argparse $options -- $argv
 
     set -l COMMAND
 

--- a/functions/__fzf_open.fish
+++ b/functions/__fzf_open.fish
@@ -11,11 +11,11 @@ function __fzf_open -d "Open files and directories."
     set -l dir $commandline[1]
     set -l fzf_query $commandline[2]
 
-    # Fish shell version >= v2.7, use argparse
-    if type -q argparse
-        set -l options "e/editor" "p/preview=?"
-        argparse $options -- $argv
-    else # Fallback for fish shell version < 2.7
+    if not type -q argparse
+        set created_argparse
+        function argparse
+            functions -e argparse # deletes itself
+        end
         if contains -- --editor $argv; or contains -- -e $argv
             set _flag_editor "yes"
         end
@@ -23,6 +23,9 @@ function __fzf_open -d "Open files and directories."
             set _flag_preview "yes"
         end
     end
+
+    set -l options "e/editor" "p/preview=?"
+    argparse $options -- $argv
 
     set -l preview_cmd
     if set -q FZF_ENABLE_OPEN_PREVIEW


### PR DESCRIPTION
#87 actually broke Fish = 2.7.  _flag_editor is local to each if branch, and remains unset further down in the file. Funnily enough, it will start working again in fish v3, that's one of the breaking changes (if blocks no longer introducing local scope bump, because that was stupid).

This fixes it by shimming argparse to do nothing and delete itself if it doesn't exist already, so that argparse can run outside the if block.