### PR TITLE
Avoid invoking grep/awk alias

### DIFF
--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -5,7 +5,7 @@ set -q FZF_PREVIEW_FILE_CMD; or set -U FZF_PREVIEW_FILE_CMD "head -n 10"
 set -q FZF_PREVIEW_DIR_CMD; or set -U FZF_PREVIEW_DIR_CMD "ls"
 
 function fzf_uninstall -e fzf_uninstall
-    set -l _vars (set | grep -E "^FZF.*\$" | awk '{print $1;}')
+    set -l _vars (set | command grep -E "^FZF.*\$" | command awk '{print $1;}')
     for var in $_vars
         echo $var
         eval (set -e $var)


### PR DESCRIPTION
Hi,

In such a case
```
alias grep 'grep -n --color'
```

`grep` will return the variable names with their line numbers like below
```
17:FZF_DEFAULT_OPTS
18:FZF_LEGACY_KEYBINDINGS
19:FZF_PREVIEW_DIR_CMD
20:FZF_PREVIEW_FILE_CMD
21:FZF_TMUX_HEIGHT
```

It would be better to invoke basic commands with `command`.