### PR TITLE
Disable erasing of env variables

### DIFF
--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -5,9 +5,10 @@ set -q FZF_PREVIEW_FILE_CMD; or set -U FZF_PREVIEW_FILE_CMD "head -n 10"
 set -q FZF_PREVIEW_DIR_CMD; or set -U FZF_PREVIEW_DIR_CMD "ls"
 
 function fzf_uninstall -e fzf_uninstall
-    set -l _vars (set | command grep -E "^FZF.*\$" | command awk '{print $1;}')
-    for var in $_vars
-        echo $var
-        eval (set -e $var)
-    end
+    # disabled until we figure out a sensible way to ensure user overrides
+    # are not erased
+    # set -l _vars (set | command grep -E "^FZF.*\$" | command awk '{print $1;}')
+    # for var in $_vars
+    #     eval (set -e $var)
+    # end
 end

--- a/conf.d/fzf_key_bindings.fish
+++ b/conf.d/fzf_key_bindings.fish
@@ -40,8 +40,10 @@ if set -q FZF_COMPLETE
 end
 
 function fzf_key_bindings_uninstall -e fzf_key_bindings_uninstall
-    set -l _bindings (bind -a | sed -En "s/(')?__fzf.*\$//p" | sed 's/bind/bind -e/')
-    for binding in $_bindings
-        eval $binding
-    end
+    # disabled until we figure out a sensible way to ensure user overrides
+    # are not erased
+    # set -l _bindings (bind -a | sed -En "s/(')?__fzf.*\$//p" | sed 's/bind/bind -e/')
+    # for binding in $_bindings
+    #     eval $binding
+    # end
 end


### PR DESCRIPTION
user overrides for some env variables are erased upon upgrade via fisher.

Fixes #107.