### PR TITLE
Repaint command line after abort

### DIFF
--- a/functions/__fzf_complete.fish
+++ b/functions/__fzf_complete.fish
@@ -73,6 +73,7 @@ function __fzf_complete -d 'fzf completion and print selection back to commandli
 
         # exit if user canceled
         if test -z "$query" ;and test -z "$result"
+            commandline -f repaint
             return
         end
 


### PR DESCRIPTION
When using the tab widget and aborting (ctrl+c) it, the command line would previously not be repainted, leading to the case where the user needs to start from scratch.