### PR TITLE
Enable easier customization of FZF_COMPLETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ documented.
 | `FZF_CD_WITH_HIDDEN_OPTS`   | Similar to ^                                                  | Similar to ^                                          |
 | `FZF_REVERSE_ISEARCH_OPTS`  | Similar to ^                                                  | Similar to ^                                          |
 | `FZF_OPEN_OPTS`             | Similar to ^                                                  | Similar to ^                                          |
+| `FZF_COMPLETE_OPTS`         | Similar to ^                                                  | Similar to ^                                          |
 | `FZF_TMUX`                  | Runs a tmux-friendly version of fzf instead.                  | `set -U FZF_TMUX 1`                                   |
 | `FZF_ENABLE_OPEN_PREVIEW`   | Enable preview window open command.                           | `set -U FZF_ENABLE_OPEN_PREVIEW 1`                    |
 

--- a/functions/__fzf_complete.fish
+++ b/functions/__fzf_complete.fish
@@ -106,6 +106,9 @@ function __fzf_complete -d 'fzf completion and print selection back to commandli
 end
 
 function __fzf_complete_opts_common
+    if set -q FZF_DEFAULT_OPTS
+        echo $FZF_DEFAULT_OPTS
+    end
     echo --cycle --reverse --inline-info
 end
 

--- a/functions/__fzf_complete.fish
+++ b/functions/__fzf_complete.fish
@@ -162,4 +162,7 @@ function __fzf_complete_opts -d 'fzf options for fish tab completion'
         case '*'
             echo $FZF_COMPLETE
     end
+    if set -q FZF_COMPLETE_OPTS
+        echo $FZF_COMPLETE_OPTS
+    end
 end


### PR DESCRIPTION
This PR consists of two small items:
1. Ensure that `FZF_DEFAULT_OPTS` are also used by the completion widget
2. Add a variable `FZF_COMPLETE_OPTS` (similar to e.g. `FZF_CD_OPTS`) that enable final customization of the chosen widget.