### PR TITLE
Add a symbolic link to fzf_key_bindings.fish in the top directory

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,0 +1,1 @@
+conf.d/fzf_key_bindings.fish


### PR DESCRIPTION
Oh-my-fish supports sourcing `key_bindings.fish` files at top-level automatically

This adds a symbolic link to the original file in conf.d/ 

