### PR TITLE
Fix preview error when candidate starts with '-'

### DIFF
--- a/functions/__fzf_complete.fish
+++ b/functions/__fzf_complete.fish
@@ -59,7 +59,7 @@ function __fzf_complete -d 'fzf completion and print selection back to commandli
         set -l query
         string join -- \n $complist \
         | sort \
-        | eval (__fzfcmd) $initial_query --print-query (__fzf_complete_opts) \
+        | eval (__fzfcmd) (string escape -- $initial_query) --print-query (__fzf_complete_opts) \
         | cut -f1 \
         | while read -l r
             # first line is the user entered query

--- a/functions/__fzf_complete.fish
+++ b/functions/__fzf_complete.fish
@@ -98,7 +98,7 @@ function __fzf_complete -d 'fzf completion and print selection back to commandli
             case '~'
                 commandline -t -- (string sub -s 2 (string escape -n -- $r))
             case '*'
-                commandline -t -- (string escape -n -- $r)
+                commandline -t -- $r
         end
         [ $i -lt (count $result) ]; and commandline -i ' '
     end

--- a/functions/__fzf_complete_preview.fish
+++ b/functions/__fzf_complete_preview.fish
@@ -11,7 +11,7 @@ function __fzf_complete_preview -d 'generate preview for completion widget.
         echo $argv[1]
     end
 
-    set -l path (string replace "~" $HOME $argv[1])
+    set -l path (string replace "~" $HOME -- $argv[1])
 
     # list directories on preview
     if test -d "$path"


### PR DESCRIPTION
When currently selected candidate starts with '-', `string` will treat it as an option:

![image](https://user-images.githubusercontent.com/13861843/58608930-54dfa300-82d8-11e9-8bc4-3d887ac162a3.png)

Use `--` to prevent arguments from being parsed:

![image](https://user-images.githubusercontent.com/13861843/58608961-704aae00-82d8-11e9-80b0-4bd894acec4e.png)

