### PR TITLE
Fix completion error when no initial query

### DIFF
--- a/functions/__fzf_complete.fish
+++ b/functions/__fzf_complete.fish
@@ -59,7 +59,7 @@ function __fzf_complete -d 'fzf completion and print selection back to commandli
         set -l query
         string join -- \n $complist \
         | sort \
-        | eval (__fzfcmd) (string escape -- $initial_query) --print-query (__fzf_complete_opts) \
+        | eval (__fzfcmd) (string escape --no-quoted -- $initial_query) --print-query (__fzf_complete_opts) \
         | cut -f1 \
         | while read -l r
             # first line is the user entered query


### PR DESCRIPTION
Previously, when there was no initial query given to fzf_complete, the
function executed `fzf ''`, which results in `unknown option: `. This
fixes that error by unquoting the initial query and escaping all quotes
in the query instead.

This works for me, but I just started using Fish today so let me know if
there's any issues with this!