### PR TITLE
RFC: Update keybindings to avoid keybinding conflicts [BREAKING]

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ See the [fzf documentation](https://github.com/junegunn/fzf#installation) for in
 
 | Legacy      | New Keybindings | Remarks                                         |
 | ----------- | --------------- | ----------------------------------------------- |
-| Ctrl-t      | Ctrl-f          | Find a file.                                    |
+| Ctrl-t      | Ctrl-o          | Find a file.                                    |
 | Ctrl-r      | Ctrl-r          | Search through command history.                 |
-| Alt-c       | Alt-o           | cd into sub-directories (recursively searched). |
-| Alt-Shift-c | Alt-Shift-o     | cd into sub-directories, including hidden ones. |
-| Ctrl-o      | Ctrl-o          | Open a file/dir using default editor ($EDITOR)  |
-| Ctrl-g      | Ctrl-g          | Open a file/dir using xdg-open or open command  |
+| Alt-c       | Alt-c           | cd into sub-directories (recursively searched). |
+| Alt-Shift-c | Alt-Shift-c     | cd into sub-directories, including hidden ones. |
+| Ctrl-o      | Alt-o           | Open a file/dir using default editor ($EDITOR)  |
+| Ctrl-g      | Alt-Shift-o     | Open a file/dir using xdg-open or open command  |
 
 Legacy keybindings are kept by default, but these have conflict with
 keybindings in fish 2.4.0. If you want to use the new keybindings,

--- a/conf.d/fzf_key_bindings.fish
+++ b/conf.d/fzf_key_bindings.fish
@@ -15,20 +15,20 @@ if test "$FZF_LEGACY_KEYBINDINGS" -eq 1
         bind -M insert \co '__fzf_open --editor'
     end
 else
-    bind \cf '__fzf_find_file'
+    bind \co '__fzf_find_file'
     bind \cr '__fzf_reverse_isearch'
-    bind \eo '__fzf_cd'
-    bind \eO '__fzf_cd --hidden'
-    bind \cg '__fzf_open'
-    bind \co '__fzf_open --editor'
+    bind \ec '__fzf_cd'
+    bind \eC '__fzf_cd --hidden'
+    bind \eo '__fzf_open'
+    bind \eo '__fzf_open --editor'
 
     if bind -M insert >/dev/null 2>/dev/null
-        bind -M insert \cf '__fzf_find_file'
+        bind -M insert \co '__fzf_find_file'
         bind -M insert \cr '__fzf_reverse_isearch'
-        bind -M insert \eo '__fzf_cd'
-        bind -M insert \eO '__fzf_cd --hidden'
-        bind -M insert \cg '__fzf_open'
-        bind -M insert \co '__fzf_open --editor'
+        bind -M insert \ec '__fzf_cd'
+        bind -M insert \eC '__fzf_cd --hidden'
+        bind -M insert \eo '__fzf_open'
+        bind -M insert \eo '__fzf_open --editor'
     end
 end
 


### PR DESCRIPTION
See #119 for motivation.

| New Keybindings | Remarks                                         | Changed |
| --------------- | ----------------------------------------------- | ------- |
| Ctrl-o          | Find a file.                                    | Yes     |
| Ctrl-r          | Search through command history.                 | No      |
| Alt-c           | cd into sub-directories (recursively searched). | No      |
| Alt-Shift-c     | cd into sub-directories, including hidden ones. | No      |
| Alt-o          | Open a file/dir using default editor ($EDITOR)  | Yes      |
| Alt-Shift-o           | Open a file/dir using xdg-open or open command  | Yes     |

I'm gonna leave this up for a while, and if there are no strong objections, I'll merge it in.