### PR TITLE
Fix keybinding conflict

### DIFF
--- a/conf.d/fzf_key_bindings.fish
+++ b/conf.d/fzf_key_bindings.fish
@@ -19,7 +19,7 @@ else
     bind \cr '__fzf_reverse_isearch'
     bind \ec '__fzf_cd'
     bind \eC '__fzf_cd --hidden'
-    bind \eo '__fzf_open'
+    bind \eO '__fzf_open'
     bind \eo '__fzf_open --editor'
 
     if bind -M insert >/dev/null 2>/dev/null
@@ -27,7 +27,7 @@ else
         bind -M insert \cr '__fzf_reverse_isearch'
         bind -M insert \ec '__fzf_cd'
         bind -M insert \eC '__fzf_cd --hidden'
-        bind -M insert \eo '__fzf_open'
+        bind -M insert \eO '__fzf_open'
         bind -M insert \eo '__fzf_open --editor'
     end
 end


### PR DESCRIPTION
`__fzf_open`'s new default bindings currently conflicts with `__fzf_open --editor` (introduced by ea1a4276f0259cf625fc9cb06108c64a0b526b2e). Based on the README description it is supposed to be <kbd>Alt-Shift-o</kbd> rather than <kbd>Alt-o</kbd>.