### PR TITLE
Added file that fits the structure

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,5 +1,11 @@
 if not functions -q fzf_key_bindings
   source $OMF_PATH/pkg/fzf/conf.d/fzf_key_bindings.fish
 else
-  fzf_key_bindings
+  if functions -D fzf_key_bindings | string match -r ".+vendor_functions\.d.+" -q 
+    functions -c fzf_key_bindings fzf_key_bindings_vendor
+    function fzf_key_bindings
+      source $OMF_PATH/pkg/fzf/conf.d/fzf_key_bindings.fish
+    end
+    fzf_key_bindings
+  end
 end

--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,0 +1,5 @@
+if not functions -q fzf_key_bindings
+  source $OMF_PATH/pkg/fzf/conf.d/fzf_key_bindings.fish
+else
+  fzf_key_bindings
+end


### PR DESCRIPTION
Apparently the OMF repo does not hold the correct fix for scanning dirs recursively. 

`{$OMF_CONFIG,$OMF_PATH}/pkg/*/key_bindings.fish` should be
`{$OMF_CONFIG,$OMF_PATH}/pkg/**/key_bindings.fish`

Notice the double \*\* . In addition to that it should offer wildcard searches around the key_bindings part as well.  Sadly the discussion over at omf is that they will not fix this. Therefore I thought I do a simple fix that won't introduce breaking changes. If the function is already loaded don't load it again. 