### PR TITLE
Create an "alternatives" section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ All functions
 - are lazily-loaded to keep shell startup time down
 - have preset but configurable key bindings
 
-Heavily adapted from @hauleth's PR.
-
-Note that the `fzf` utility has its [own out-of-the-box fish package](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). What sets this package apart is that it has a couple more integrations, most notably tab completion, and will probably be updated more frequently. They are not compatible so use one or the other.
-
 ## Installation
 
 With [fisher]
@@ -103,7 +99,8 @@ Please see [the wiki
 page](https://github.com/jethrokuan/fzf/wiki/FZF-Tab-Completions) for details.
 
 ## Alternatives
-[@patrickf3139](https://github.com/patrickf3139) has written a newer fzf plugin called [fzf-fish-integration](https://github.com/patrickf3139/fzf-fish-integration) with simpler but different features. It lacks Tmux support and tab completion but includes functions for searching git log and browsing shell variables using git log. Additionally, moving forward, it is more likely to be maintained. You can read more about the differences between it and this plugin in the readme of `fzf-fish-integration` [here](https://github.com/patrickf3139/fzf-fish-integration#prior-art).
+- [@patrickf3139](https://github.com/patrickf3139) has written a newer fzf plugin called [fzf-fish-integration](https://github.com/patrickf3139/fzf-fish-integration) with simpler but different features. It lacks Tmux support and tab completion but includes functions for searching git log and browsing shell variables using git log. Additionally, moving forward, it is more likely to be maintained. You can read more about the differences between it and this plugin in the readme of `fzf-fish-integration` [here](https://github.com/patrickf3139/fzf-fish-integration#prior-art).
+- The `fzf` utility has its [own official out-of-the-box fish integration](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). What sets this package apart is that it has a couple more integrations, most notably tab completion. They are not compatible so use one or the other.
 
 ###
 [tmux]: https://tmux.github.io/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Please see [the wiki
 page](https://github.com/jethrokuan/fzf/wiki/FZF-Tab-Completions) for details.
 
 ## Alternatives
-- [@patrickf3139](https://github.com/patrickf3139) has written a newer fzf plugin called [fzf-fish-integration](https://github.com/patrickf3139/fzf-fish-integration) with simpler but different features. It lacks Tmux support and tab completion but includes functions for searching git log and browsing shell variables using git log. Additionally, moving forward, it is more likely to be maintained. You can read more about the differences between it and this plugin in the readme of `fzf-fish-integration` [here](https://github.com/patrickf3139/fzf-fish-integration#prior-art).
+- [fzf-fish-integration](https://github.com/patrickf3139/fzf-fish-integration) is a newer fzf plugin with very similar but simpler features. It lacks Tmux support and fzf tab completion but includes functions for searching git log and browsing shell variables using git log. Additionally, moving forward, it is more likely to be maintained. You can read more about the differences between it and this plugin in the readme of `fzf-fish-integration` [here](https://github.com/patrickf3139/fzf-fish-integration#prior-art).
 - The `fzf` utility has its [own official out-of-the-box fish integration](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). What sets this package apart is that it has a couple more integrations, most notably tab completion. They are not compatible so use one or the other.
 
 ###

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All functions
 
 Heavily adapted from @hauleth's PR.
 
-Note that the `fzf` utility has its [own out-of-the-box fish package](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). What sets this package apart is that it has a couple more integrations, most notably tab completion, and will probably be updated more frequently. They are not compatible so either use one or the other.
+Note that the `fzf` utility has its [own out-of-the-box fish package](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). What sets this package apart is that it has a couple more integrations, most notably tab completion, and will probably be updated more frequently. They are not compatible so use one or the other.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ This package ships with a `fzf` widget for fancy tab completions.
 Please see [the wiki
 page](https://github.com/jethrokuan/fzf/wiki/FZF-Tab-Completions) for details.
 
+## Alternatives
+[@patrickf3139](https://github.com/patrickf3139) has written a newer fzf plugin called [fzf-fish-integration](https://github.com/patrickf3139/fzf-fish-integration) with simpler but different features. It lacks Tmux support and tab completion but includes functions for searching git log and browsing shell variables using git log. Additionally, moving forward, it is more likely to be maintained. You can read more about the differences between it and this plugin in the readme of `fzf-fish-integration` [here](https://github.com/patrickf3139/fzf-fish-integration#prior-art).
+
 ###
 [tmux]: https://tmux.github.io/
 [fisher]: https://github.com/jorgebucaran/fisher


### PR DESCRIPTION
1. Remove note about `Heavily adapted from @hauleth's PR.`, which is doesn't link to it and is confusing anyway.
2. Move note about fzf out of the box fish integration into alternatives section and fix some grammar.
3. Add mention of my plugin in alternatives section.