### PR TITLE
Remove perl dependency in __fzf_reverse_isearch

### DIFF
--- a/functions/__fzf_reverse_isearch.fish
+++ b/functions/__fzf_reverse_isearch.fish
@@ -1,6 +1,6 @@
 function __fzf_reverse_isearch
     history merge
-    history -z | eval (__fzfcmd) --read0 --tiebreak=index --toggle-sort=ctrl-r $FZF_DEFAULT_OPTS $FZF_REVERSE_ISEARCH_OPTS -q '(commandline)' | perl -pe 'chomp if eof' | read -lz result
+    history -z | eval (__fzfcmd) --read0 --print0 --tiebreak=index --toggle-sort=ctrl-r $FZF_DEFAULT_OPTS $FZF_REVERSE_ISEARCH_OPTS -q '(commandline)' | read -lz result
     and commandline -- $result
     commandline -f repaint
 end


### PR DESCRIPTION
Because read `-lz` reads null-delimited lines, `fzf --print0` can be used instead of piping output to `perl -pe 'chomp if eof'`.