### PR TITLE
rename fzf-fish-integration to fzf.fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Please see [the wiki
 page](https://github.com/jethrokuan/fzf/wiki/FZF-Tab-Completions) for details.
 
 ## Alternatives
-- [fzf-fish-integration](https://github.com/patrickf3139/fzf-fish-integration) is a newer fzf plugin with very similar features. It lacks Tmux support and fzf tab completion but includes functions for searching git log and browsing shell variables using fzf. Additionally, it is more likely to be maintained going forward. You can read more about the differences between it and this plugin in the readme of `fzf-fish-integration` [here](https://github.com/patrickf3139/fzf-fish-integration#prior-art).
+- [fzf.fish](https://github.com/patrickf3139/fzf.fish) is a newer fzf plugin with very similar features. It lacks Tmux support and fzf tab completion but includes functions for searching git log, git status, and browsing shell variables using fzf. Additionally, it is more likely to be maintained going forward. You can read more about the differences between it and this plugin in the readme of `fzf.fish` [here](https://github.com/patrickf3139/fzf.fish#prior-art).
 - The `fzf` utility ships with its [own out-of-the-box fish integration](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish). What sets this package apart is that it has a couple more integrations, most notably tab completion. They are not compatible so use one or the other.
 
 ###


### PR DESCRIPTION
Hi Jethro, sorry for bothering you with my 3rd PR yet on this topic. I renamed my plugin a while ago and though GitHub does handle redirects, I thought it would be better for both of us if I just renamed it here as well. Thank you for maintaining this!