### PR TITLE
Allow using a different finder program

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ documented.
 | `FZF_CD_COMMAND`               | Similar to ^                                                | Similar to ^                                                  |
 | `FZF_CD_WITH_HIDDEN_COMMAND`   | Similar to ^                                                | Similar to ^                                                  |
 | `FZF_OPEN_COMMAND`             | Similar to ^                                                | Similar to ^                                                  |
-| `FZF_PREVIEW_FILE_CMD`     | Modify the command used to generate preview of files.       | `set -U FZF_PREVIEW_FILE_CMD "head -n 10"`                |
-| `FZF_PREVIEW_DIR_CMD`      | Modify the command used to generate preview of directories. | `set -U FZF_PREVIEW_DIR_CMD "ls"`                        |
+| `FZF_PREVIEW_FILE_CMD`         | Modify the command used to generate preview of files.       | `set -U FZF_PREVIEW_FILE_CMD "head -n 10"`                    |
+| `FZF_PREVIEW_DIR_CMD`          | Modify the command used to generate preview of directories. | `set -U FZF_PREVIEW_DIR_CMD "ls"`                             |
+| `FZF_CMD`                      | Modify the finder program used to search                    | `set -U FZF_CMD fzf`                                          |
+| `FZF_TMUX_CMD`                 | Modify the finder program used to search (tmux-friendly)    | `set -U FZF_TMUX_CMD fzf-tmux`                                |
 
 ## Variables
 

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -4,6 +4,8 @@ set -q FZF_LEGACY_KEYBINDINGS; or set -U FZF_LEGACY_KEYBINDINGS 1
 set -q FZF_DISABLE_KEYBINDINGS; or set -U FZF_DISABLE_KEYBINDINGS 0
 set -q FZF_PREVIEW_FILE_CMD; or set -U FZF_PREVIEW_FILE_CMD "head -n 10"
 set -q FZF_PREVIEW_DIR_CMD; or set -U FZF_PREVIEW_DIR_CMD "ls"
+set -q FZF_CMD; or set -U FZF_CMD "fzf"
+set -q FZF_TMUX_CMD; or set -U FZF_CMD "fzf-tmux"
 
 function fzf_uninstall -e fzf_uninstall
     # disabled until we figure out a sensible way to ensure user overrides

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -5,7 +5,7 @@ set -q FZF_DISABLE_KEYBINDINGS; or set -U FZF_DISABLE_KEYBINDINGS 0
 set -q FZF_PREVIEW_FILE_CMD; or set -U FZF_PREVIEW_FILE_CMD "head -n 10"
 set -q FZF_PREVIEW_DIR_CMD; or set -U FZF_PREVIEW_DIR_CMD "ls"
 set -q FZF_CMD; or set -U FZF_CMD "fzf"
-set -q FZF_TMUX_CMD; or set -U FZF_CMD "fzf-tmux"
+set -q FZF_TMUX_CMD; or set -U FZF_TMUX_CMD "fzf-tmux"
 
 function fzf_uninstall -e fzf_uninstall
     # disabled until we figure out a sensible way to ensure user overrides

--- a/functions/__fzfcmd.fish
+++ b/functions/__fzfcmd.fish
@@ -2,8 +2,8 @@ function __fzfcmd
     set -q FZF_TMUX; or set FZF_TMUX 0
     set -q FZF_TMUX_HEIGHT; or set FZF_TMUX_HEIGHT 40%
     if [ $FZF_TMUX -eq 1 ]
-        echo "fzf-tmux -d$FZF_TMUX_HEIGHT"
+        echo "$FZF_TMUX_CMD -d$FZF_TMUX_HEIGHT"
     else
-        echo "fzf"
+        echo "$FZF_CMD"
     end
 end


### PR DESCRIPTION
The use of `__fzfcmd` makes it easy to use another finder program, and I think this can be further developed into a feature in case users prefer a different finder (such as [skim](https://github.com/lotabout/skim)).

This PR adds `FZF_CMD` and `FZF_TMUX_CMD` variables so users can change the finder with ease.