### PR TITLE
Don't bind tab if tab has bindings already

### DIFF
--- a/conf.d/fzf_key_bindings.fish
+++ b/conf.d/fzf_key_bindings.fish
@@ -35,6 +35,7 @@ if test "$FZF_DISABLE_KEYBINDINGS" -ne 1
 
     if ! count (bind --user \t) >/dev/null
         if set -q FZF_COMPLETE
+            bind \t '__fzf_complete'
             if bind -M insert >/dev/null 2>/dev/null
                 bind -M insert \t '__fzf_complete'
             end

--- a/conf.d/fzf_key_bindings.fish
+++ b/conf.d/fzf_key_bindings.fish
@@ -33,10 +33,11 @@ if test "$FZF_DISABLE_KEYBINDINGS" -ne 1
         end
     end
 
-    if set -q FZF_COMPLETE
-        bind \t '__fzf_complete'
-        if bind -M insert >/dev/null 2>/dev/null
-            bind -M insert \t '__fzf_complete'
+    if ! count (bind --user \t) >/dev/null
+        if set -q FZF_COMPLETE
+            if bind -M insert >/dev/null 2>/dev/null
+                bind -M insert \t '__fzf_complete'
+            end
         end
     end
 end


### PR DESCRIPTION
[Tab support is tricky](https://github.com/jethrokuan/fzf/issues?q=is%3Aissue+tab). I don't propose we remove tab binding support outright, but we could improve our situation a bit.

By merging this PR, fzf will no longer bind tab if bindings for tab are already present. I considered wrapping existing tab bindings instead, but because fzf takes partial control of the screen it's difficult to imagine fzf tab bindings being compatible with any other plugin.

This would help with simple cases like https://github.com/jethrokuan/fzf/issues/167.