### PR TITLE
Use `cd` function instead of `builtin cd`

### DIFF
--- a/functions/__fzf_cd.fish
+++ b/functions/__fzf_cd.fish
@@ -39,7 +39,7 @@ function __fzf_cd -d "Change directory"
     eval "$COMMAND | "(__fzfcmd)" +m $FZF_DEFAULT_OPTS $FZF_CD_OPTS --query \"$fzf_query\"" | read -l select
 
     if not test -z "$select"
-        builtin cd "$select"
+        cd "$select"
 
         # Remove last token from commandline.
         commandline -t ""


### PR DESCRIPTION
`builtin cd` doesn't track history, so running `cd -` after using `__fzf_cd` to change directory doesn't have the expected behavior of moving back to the previous directory.